### PR TITLE
Correcting a few issues in the ControllerFactory

### DIFF
--- a/Plumbing/WindsorControllerFactory.cs.pp
+++ b/Plumbing/WindsorControllerFactory.cs.pp
@@ -16,10 +16,11 @@ namespace $rootnamespace$.Plumbing
         }
 
         protected override IController GetControllerInstance(RequestContext requestContext, Type controllerType)
-        {
-            if (controllerType == null)
-                throw new HttpException(404, String.Format("The requested controller for path '{0}' could not be found", requestContext.HttpContext.Request.Path));
-            return (IController)container.Resolve(controllerType);
+        {            
+			if (controllerType != null && container.HasComponent(controllerType))
+				return (IController)container.Resolve(controllerType);
+
+			return base.GetControllerInstance(requestContext, controllerType);
         }
 
         public override void ReleaseController(IController controller)

--- a/Plumbing/WindsorControllerFactory.cs.pp
+++ b/Plumbing/WindsorControllerFactory.cs.pp
@@ -17,7 +17,7 @@ namespace $rootnamespace$.Plumbing
 
         protected override IController GetControllerInstance(RequestContext requestContext, Type controllerType)
         {            
-			if (controllerType != null && container.HasComponent(controllerType))
+			if (controllerType != null && container.Kernel.HasComponent(controllerType))
 				return (IController)container.Resolve(controllerType);
 
 			return base.GetControllerInstance(requestContext, controllerType);

--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
 Castle.Windsor ASP.NET MVC bootstrapping package
 ------------------------------------------------
 
-This package simplyfies bootstrapping of `Castle.Windsor` container in your ASP.NET MVC 4 application. 
+This package simplifies bootstrapping of `Castle.Windsor` container in your ASP.NET MVC 4 application. 
 To install this package, use following NuGet command:
 
     PM> Install-Package Castle.Windsor.Web.Mvc


### PR DESCRIPTION
The DefaultControllerFactory handles throwing errors when it doesn't know what to do or the controllerType is null, and it's message is properly localized, so it makes more sense to allow it to handle this situation than to double-implement that. 

This change lets users of this nuget package avoid having to add route ignores for all URLs not handled by the controller factory to avoid debugger breaking (eg. favicon.ico as mentioned in the comments here: http://docs.castleproject.org/(S(kwaa14uzdj55gv55dzgf0vui))/Windsor.Windsor-tutorial-part-two-plugging-Windsor-in.ashx?Discuss=1).

Also fixed a spelling error in the readme.
